### PR TITLE
Support variables in graphql queries

### DIFF
--- a/lib/graphQl/resolvers.js
+++ b/lib/graphQl/resolvers.js
@@ -12,7 +12,7 @@ resolvers.search = (resourceConfig, attribute, parent, args, req, ast) => {
   // If we don't have a JSON:API resource, go get it
   if (!parent) {
     path = jsonApi._apiConfig.pathPrefix + resourceConfig.resource
-    return resolvers.rerouteTo('GET', path, { }, req, ast)
+    return resolvers.rerouteTo('GET', path, { filter: args }, req, ast)
   }
   // Simple attributes can be plucked from the JSON:API resource
   if (!resourceConfig.attributes[attribute]._settings) {
@@ -20,7 +20,7 @@ resolvers.search = (resourceConfig, attribute, parent, args, req, ast) => {
   }
   // Related resources need to be requested via the related link
   path = parent.relationships[attribute].links.related
-  return resolvers.rerouteTo('GET', path, { }, req, ast)
+  return resolvers.rerouteTo('GET', path, { filter: args }, req, ast)
 }
 
 resolvers.create = (resourceConfig, parent, args, req, ast) => {

--- a/test/graphQl.js
+++ b/test/graphQl.js
@@ -68,6 +68,22 @@ describe('Testing jsonapi-server graphql', () => {
         ]
       })
     }))
+
+    it('filters with variables', () => client.query(`
+      query People($firstname: String!) {
+        people(firstname: $firstname) {
+          lastname
+        }
+      }
+    `, { firstname: 'Rahul' }).then(result => {
+      assert.deepEqual(result, {
+        'people': [
+          {
+            'lastname': 'Patel'
+          }
+        ]
+      })
+    }))
   })
 
   describe('write operations', () => {


### PR DESCRIPTION
I'm not sure if this is the best way to implement it but this PR adds support for graphql queries with variables, such as:
```
      query People($firstname: String!) {
        people(firstname: $firstname) {
          lastname
        }
      }
```

