### PR TITLE
Fix for config types not matching documentation

### DIFF
--- a/types/ResourceConfig.d.ts
+++ b/types/ResourceConfig.d.ts
@@ -1,8 +1,8 @@
 /**
  * @module @jagql/framework
  */
-import { Schema } from 'joi'
-import { Handler } from './Handler'
+import {Schema} from 'joi'
+import {Handler} from './Handler'
 
 export type BaseType = {
   id?: string

--- a/types/ResourceConfig.d.ts
+++ b/types/ResourceConfig.d.ts
@@ -1,24 +1,31 @@
 /**
  * @module @jagql/framework
  */
-import {Schema} from 'joi'
-import {Handler} from './Handler'
+import { Schema } from 'joi'
+import { Handler } from './Handler'
 
 export type BaseType = {
   id?: string
   type: string
 }
+
 export type ResourceAttributes<Item> = {
   [x in keyof Item]: Schema
-  }
+}
 
-type PrimaryKeyType ='uuid' | 'autoincrement' | 'string'
+export type OptionalResourceAttributes<Item> = {
+  [x in keyof Item]?: Schema
+}
+
+type PrimaryKeyType = 'uuid' | 'autoincrement' | 'string'
 
 export interface ResourceConfig<Item> {
   namespace?: string,
+  description?: string,
   resource: string,
   handlers: Handler
   primaryKey: PrimaryKeyType,
   attributes: ResourceAttributes<Item>
   examples: (BaseType & Item)[]
+  searchParams?: OptionalResourceAttributes<Item>
 }

--- a/types/jsonApi.d.ts
+++ b/types/jsonApi.d.ts
@@ -4,13 +4,13 @@
 
 /// <reference types="express" />
 
-import {Application, Request} from 'express'
-import {Schema} from 'joi'
+import { Application, Request, Router } from 'express'
+import { Schema } from 'joi'
 import OurJoi = require('./ourJoi')
 import ChainHandlerType = require('./ChainHandler')
 import MemoryHandlerType = require('./MemoryHandler')
-import {ResourceConfig} from './ResourceConfig'
-import {Metrics} from './metrics'
+import { ResourceConfig } from './ResourceConfig'
+import { Metrics } from './metrics'
 import * as RC from './ResourceConfig'
 import * as H from './Handler'
 
@@ -23,12 +23,15 @@ export import BaseType = RC.BaseType
 interface ApiConfig {
   graphiql?: boolean
   jsonapi?: boolean
-  protocol: JsonApiProtocols
-  hostname: string
+  protocol?: JsonApiProtocols
+  urlPrefixAlias?: string
+  hostname?: string
   port: number
-  base: string,
-  meta: any
+  base?: string,
+  meta?: any
   swagger?: any
+  router?: Router
+  bodyParserJsonOpts?: any
 }
 /**
  * Our modified Joi instance
@@ -36,40 +39,40 @@ interface ApiConfig {
 export const Joi: typeof OurJoi.Joi
 
 /**
- * Configure things like - 
+ * Configure things like -
  *  - http/https
  *  - host, port
  *  - enable/disable graphql and swagger
- * 
- * For detailed info please check https://jagql.github.io/docs/pages/configuration.html 
+ *
+ * For detailed info please check https://jagql.github.io/docs/pages/configuration.html
  * @param {ApiConfig} apiConfig
  */
-export function setConfig(apiConfig: ApiConfig): void
+export function setConfig (apiConfig: ApiConfig): void
 
 /**
  * [[include:resources.md]]
  * @param {ResourceConfig<T>} resConfig
  */
-export function define<T>(resConfig: ResourceConfig<T>): void
-export function authenticate(authenticator: (req: Request, cb: () => void) => void): void
+export function define<T> (resConfig: ResourceConfig<T>): void
+export function authenticate (authenticator: (req: Request, cb: () => void) => void): void
 
 /**
- * Application metrics are generated and exposed via an event emitter interface. 
- * Whenever a request has been processed and it about to be returned to the customer, 
+ * Application metrics are generated and exposed via an event emitter interface.
+ * Whenever a request has been processed and it about to be returned to the customer,
  * a `data` event will be emitted:
- * 
+ *
  * ```javascript
  * jsonApi.metrics.on("data", function(data) {
  *   // send data to your metrics stack
  * });
  * ```
- * 
+ *
  * For details read - https://jagql.github.io/docs/pages/debugging/metrics.html
  */
 export const metrics: Metrics
-export function getExpressServer(): Application
+export function getExpressServer (): Application
 export const ChainHandler: typeof ChainHandlerType
 export const MemoryHandler: typeof MemoryHandlerType
-export function onUncaughtException(err: Error): void
-export function start(callback: Function): void
-export function close(): void
+export function onUncaughtException (err: Error): void
+export function start (callback: Function): void
+export function close (): void

--- a/types/jsonApi.d.ts
+++ b/types/jsonApi.d.ts
@@ -4,13 +4,13 @@
 
 /// <reference types="express" />
 
-import { Application, Request, Router } from 'express'
-import { Schema } from 'joi'
+import {Application, Request, Router} from 'express'
+import {Schema} from 'joi'
 import OurJoi = require('./ourJoi')
 import ChainHandlerType = require('./ChainHandler')
 import MemoryHandlerType = require('./MemoryHandler')
-import { ResourceConfig } from './ResourceConfig'
-import { Metrics } from './metrics'
+import {ResourceConfig} from './ResourceConfig'
+import {Metrics} from './metrics'
 import * as RC from './ResourceConfig'
 import * as H from './Handler'
 
@@ -47,14 +47,14 @@ export const Joi: typeof OurJoi.Joi
  * For detailed info please check https://jagql.github.io/docs/pages/configuration.html
  * @param {ApiConfig} apiConfig
  */
-export function setConfig (apiConfig: ApiConfig): void
+export function setConfig(apiConfig: ApiConfig): void
 
 /**
  * [[include:resources.md]]
  * @param {ResourceConfig<T>} resConfig
  */
-export function define<T> (resConfig: ResourceConfig<T>): void
-export function authenticate (authenticator: (req: Request, cb: () => void) => void): void
+export function define<T>(resConfig: ResourceConfig<T>): void
+export function authenticate(authenticator: (req: Request, cb: () => void) => void): void
 
 /**
  * Application metrics are generated and exposed via an event emitter interface.
@@ -70,9 +70,9 @@ export function authenticate (authenticator: (req: Request, cb: () => void) => v
  * For details read - https://jagql.github.io/docs/pages/debugging/metrics.html
  */
 export const metrics: Metrics
-export function getExpressServer (): Application
+export function getExpressServer(): Application
 export const ChainHandler: typeof ChainHandlerType
 export const MemoryHandler: typeof MemoryHandlerType
-export function onUncaughtException (err: Error): void
-export function start (callback: Function): void
-export function close (): void
+export function onUncaughtException(err: Error): void
+export function start(callback: Function): void
+export function close(): void

--- a/types/jsonApi.d.ts
+++ b/types/jsonApi.d.ts
@@ -23,12 +23,12 @@ export import BaseType = RC.BaseType
 interface ApiConfig {
   graphiql?: boolean
   jsonapi?: boolean
-  protocol?: JsonApiProtocols
+  protocol: JsonApiProtocols
   urlPrefixAlias?: string
-  hostname?: string
+  hostname: string
   port: number
-  base?: string,
-  meta?: any
+  base: string,
+  meta: any
   swagger?: any
   router?: Router
   bodyParserJsonOpts?: any


### PR DESCRIPTION
As was pointed out in #104, the `ApiConfig` interface does not match the documentation as it is written [here](https://jagql.github.io/pages/configuration.html#setting-the-configuration).
The same is true with the `ResourceConfig`, as it was missing two fields compared to how it was used in the [documentation](https://jagql.github.io/pages/project_setup/resources.html) and in [examples](https://github.com/jagql/framework/tree/master/example/resources).