### PR TITLE
Replace HTTP 403 error status with HTTP 400

### DIFF
--- a/lib/routes/helper.js
+++ b/lib/routes/helper.js
@@ -14,8 +14,8 @@ helper.validate = (someObject, someDefinition, callback) => {
   Joi.validate(someObject, someDefinition, { abortEarly: false }, (err, sanitisedObject) => {
     if (err) {
       return callback({ // eslint-disable-line standard/no-callback-literal
-        status: '403',
-        code: 'EFORBIDDEN',
+        status: '400',
+        code: 'EBADREQUEST',
         title: 'Param validation failed',
         detail: err.details
       })
@@ -28,8 +28,8 @@ helper.validate = (someObject, someDefinition, callback) => {
 helper.checkForBody = (request, callback) => {
   if (!request.params.data) {
     return callback({ // eslint-disable-line standard/no-callback-literal
-      status: '403',
-      code: 'EFORBIDDEN',
+      status: '400',
+      code: 'EBADREQUEST',
       title: 'Request validation failed',
       detail: 'Missing "data" - have you sent the right http headers?'
     })
@@ -37,8 +37,8 @@ helper.checkForBody = (request, callback) => {
   // data can be {} or [] both of which are typeof === 'object'
   if (typeof request.params.data !== 'object') {
     return callback({ // eslint-disable-line standard/no-callback-literal
-      status: '403',
-      code: 'EFORBIDDEN',
+      status: '400',
+      code: 'EBADREQUEST',
       title: 'Request validation failed',
       detail: '"data" must be an object - have you sent the right http headers?'
     })


### PR DESCRIPTION
HTTP 400 status code fits better in a context where the client is responsible for the error, i.e., when the client sends unexpected or malformed data. MDN reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400